### PR TITLE
SD-1352 As a System I can store MetaData for Spree Resources (#11400)

### DIFF
--- a/api/spec/serializers/spree/api/v2/platform/address_serializer_spec.rb
+++ b/api/spec/serializers/spree/api/v2/platform/address_serializer_spec.rb
@@ -28,6 +28,8 @@ describe Spree::Api::V2::Platform::AddressSerializer do
             updated_at: address.updated_at,
             deleted_at: address.deleted_at,
             label: address.label,
+            public_metadata: {},
+            private_metadata: {}
           },
           relationships: {
             country: {

--- a/api/spec/serializers/spree/api/v2/platform/asset_serializer_spec.rb
+++ b/api/spec/serializers/spree/api/v2/platform/asset_serializer_spec.rb
@@ -24,7 +24,9 @@ describe Spree::Api::V2::Platform::AssetSerializer do
           attachment_updated_at: resource.attachment_updated_at,
           alt: resource.alt,
           created_at: resource.created_at,
-          updated_at: resource.updated_at
+          updated_at: resource.updated_at,
+          public_metadata: resource.public_metadata,
+          private_metadata: resource.private_metadata
         },
         relationships: {
           viewable: {

--- a/api/spec/serializers/spree/api/v2/platform/option_type_serializer_spec.rb
+++ b/api/spec/serializers/spree/api/v2/platform/option_type_serializer_spec.rb
@@ -19,7 +19,9 @@ describe Spree::Api::V2::Platform::OptionTypeSerializer do
             position: option_type.position,
             created_at: option_type.created_at,
             updated_at: option_type.updated_at,
-            filterable: option_type.filterable
+            filterable: option_type.filterable,
+            public_metadata: {},
+            private_metadata: {}
           },
           relationships: {
             option_values: {

--- a/api/spec/serializers/spree/api/v2/platform/option_value_serializer_spec.rb
+++ b/api/spec/serializers/spree/api/v2/platform/option_value_serializer_spec.rb
@@ -18,7 +18,9 @@ describe Spree::Api::V2::Platform::OptionValueSerializer do
             name: option_value.name,
             presentation: option_value.presentation,
             created_at: option_value.created_at,
-            updated_at: option_value.updated_at
+            updated_at: option_value.updated_at,
+            public_metadata: {},
+            private_metadata: {}
           },
           relationships: {
             option_type: {

--- a/api/spec/serializers/spree/api/v2/platform/product_serializer_spec.rb
+++ b/api/spec/serializers/spree/api/v2/platform/product_serializer_spec.rb
@@ -43,7 +43,9 @@ describe Spree::Api::V2::Platform::ProductSerializer do
           price: BigDecimal(10),
           display_price: '$10.00',
           compare_at_price: BigDecimal(15),
-          display_compare_at_price: '$15.00'
+          display_compare_at_price: '$15.00',
+          public_metadata: {},
+          private_metadata: {}
         },
         relationships: {
           tax_category: {

--- a/api/spec/serializers/spree/api/v2/platform/property_serializer_spec.rb
+++ b/api/spec/serializers/spree/api/v2/platform/property_serializer_spec.rb
@@ -19,7 +19,9 @@ describe Spree::Api::V2::Platform::PropertySerializer do
           created_at: resource.created_at,
           updated_at: resource.updated_at,
           filterable: resource.filterable,
-          filter_param: resource.filter_param
+          filter_param: resource.filter_param,
+          public_metadata: resource.public_metadata,
+          private_metadata: resource.private_metadata
         }
       }
     )

--- a/api/spec/serializers/spree/api/v2/platform/prototype_serializer_spec.rb
+++ b/api/spec/serializers/spree/api/v2/platform/prototype_serializer_spec.rb
@@ -18,7 +18,9 @@ describe Spree::Api::V2::Platform::PrototypeSerializer do
         attributes: {
           name: resource.name,
           created_at: resource.created_at,
-          updated_at: resource.updated_at
+          updated_at: resource.updated_at,
+          public_metadata: resource.public_metadata,
+          private_metadata: resource.private_metadata
         },
         relationships: {
           properties: {

--- a/api/spec/serializers/spree/api/v2/platform/stock_transfer_serializer_spec.rb
+++ b/api/spec/serializers/spree/api/v2/platform/stock_transfer_serializer_spec.rb
@@ -23,7 +23,9 @@ describe Spree::Api::V2::Platform::StockTransferSerializer do
           reference: resource.reference,
           created_at: resource.created_at,
           updated_at: resource.updated_at,
-          number: resource.number
+          number: resource.number,
+          public_metadata: resource.public_metadata,
+          private_metadata: resource.private_metadata
         },
         relationships: {
           stock_movements: {

--- a/api/spec/serializers/spree/api/v2/platform/taxon_serializer_spec.rb
+++ b/api/spec/serializers/spree/api/v2/platform/taxon_serializer_spec.rb
@@ -35,7 +35,9 @@ describe Spree::Api::V2::Platform::TaxonSerializer do
               seo_title: taxon.seo_title,
               is_root: taxon.root?,
               is_child: taxon.child?,
-              is_leaf: taxon.leaf?
+              is_leaf: taxon.leaf?,
+              public_metadata: {},
+              private_metadata: {}
             },
             relationships: {
               parent: {
@@ -103,7 +105,9 @@ describe Spree::Api::V2::Platform::TaxonSerializer do
               seo_title: taxon.seo_title,
               is_root: taxon.root?,
               is_child: taxon.child?,
-              is_leaf: taxon.leaf?
+              is_leaf: taxon.leaf?,
+              public_metadata: {},
+              private_metadata: {}
             },
             relationships: {
               parent: {

--- a/api/spec/serializers/spree/api/v2/platform/taxonomy_serializer_spec.rb
+++ b/api/spec/serializers/spree/api/v2/platform/taxonomy_serializer_spec.rb
@@ -25,7 +25,9 @@ describe Spree::Api::V2::Platform::TaxonomySerializer, retry: 3 do
             name: taxonomy.name,
             created_at: taxonomy.created_at,
             updated_at: taxonomy.updated_at,
-            position: taxonomy.position
+            position: taxonomy.position,
+            public_metadata: {},
+            private_metadata: {}
           },
           relationships: {
             root: {

--- a/api/spec/serializers/spree/api/v2/platform/variant_serializer_spec.rb
+++ b/api/spec/serializers/spree/api/v2/platform/variant_serializer_spec.rb
@@ -41,7 +41,9 @@ describe Spree::Api::V2::Platform::VariantSerializer do
             price: BigDecimal(10),
             display_price: '$10.00',
             compare_at_price: BigDecimal(15),
-            display_compare_at_price: '$15.00'
+            display_compare_at_price: '$15.00',
+            public_metadata: {},
+            private_metadata: {}
           },
           relationships: {
             product: {

--- a/core/app/models/concerns/spree/metadata.rb
+++ b/core/app/models/concerns/spree/metadata.rb
@@ -1,0 +1,10 @@
+module Spree
+  module Metadata
+    extend ActiveSupport::Concern
+
+    included do
+      store :public_metadata, coder: JSON
+      store :private_metadata, coder: JSON
+    end
+  end
+end

--- a/core/app/models/spree/address.rb
+++ b/core/app/models/spree/address.rb
@@ -2,6 +2,8 @@ module Spree
   class Address < Spree::Base
     require 'validates_zipcode'
 
+    include Metadata
+
     if Rails::VERSION::STRING >= '6.1'
       serialize :preferences, Hash, default: {}
     end

--- a/core/app/models/spree/asset.rb
+++ b/core/app/models/spree/asset.rb
@@ -1,6 +1,7 @@
 module Spree
   class Asset < Spree::Base
     include Support::ActiveStorage
+    include Metadata
 
     belongs_to :viewable, polymorphic: true, touch: true
     acts_as_list scope: [:viewable_id, :viewable_type]

--- a/core/app/models/spree/credit_card.rb
+++ b/core/app/models/spree/credit_card.rb
@@ -1,6 +1,7 @@
 module Spree
   class CreditCard < Spree::Base
     include ActiveMerchant::Billing::CreditCardMethods
+    include Metadata
 
     acts_as_paranoid
 

--- a/core/app/models/spree/customer_return.rb
+++ b/core/app/models/spree/customer_return.rb
@@ -2,6 +2,7 @@ module Spree
   class CustomerReturn < Spree::Base
     include Spree::Core::NumberGenerator.new(prefix: 'CR', length: 9)
     include NumberIdentifier
+    include Metadata
 
     belongs_to :stock_location
     belongs_to :store, class_name: 'Spree::Store', inverse_of: :customer_returns

--- a/core/app/models/spree/legacy_user.rb
+++ b/core/app/models/spree/legacy_user.rb
@@ -4,6 +4,7 @@ module Spree
     include UserAddress
     include UserPaymentSource
     include UserMethods
+    include Spree::Metadata
 
     self.table_name = 'spree_users'
 

--- a/core/app/models/spree/line_item.rb
+++ b/core/app/models/spree/line_item.rb
@@ -1,5 +1,7 @@
 module Spree
   class LineItem < Spree::Base
+    include Metadata
+
     before_validation :ensure_valid_quantity
 
     with_options inverse_of: :line_items do

--- a/core/app/models/spree/option_type.rb
+++ b/core/app/models/spree/option_type.rb
@@ -1,6 +1,7 @@
 module Spree
   class OptionType < Spree::Base
     include UniqueName
+    include Metadata
 
     acts_as_list
 

--- a/core/app/models/spree/option_value.rb
+++ b/core/app/models/spree/option_value.rb
@@ -1,5 +1,7 @@
 module Spree
   class OptionValue < Spree::Base
+    include Metadata
+
     belongs_to :option_type, class_name: 'Spree::OptionType', touch: true, inverse_of: :option_values
     acts_as_list scope: :option_type
 

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -24,6 +24,7 @@ module Spree
     include NumberAsParam
     include SingleStoreResource
     include MemoizedData
+    include Metadata
 
     MEMOIZED_METHODS = %w(tax_zone)
 

--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -5,6 +5,7 @@ module Spree
     include Spree::Core::NumberGenerator.new(prefix: 'P', letters: true, length: 7)
     include NumberIdentifier
     include NumberAsParam
+    include Metadata
 
     include Spree::Payment::Processing
 

--- a/core/app/models/spree/payment_method.rb
+++ b/core/app/models/spree/payment_method.rb
@@ -4,6 +4,7 @@ module Spree
     acts_as_list
 
     include MultiStoreResource
+    include Spree::Metadata
 
     DISPLAY = [:both, :front_end, :back_end].freeze
 

--- a/core/app/models/spree/product.rb
+++ b/core/app/models/spree/product.rb
@@ -24,6 +24,7 @@ module Spree
     include ProductScopes
     include MultiStoreResource
     include MemoizedData
+    include Metadata
 
     MEMOIZED_METHODS = %w(total_on_hand taxonomy_ids taxon_and_ancestors category
                           default_variant_id tax_category default_variant

--- a/core/app/models/spree/promotion.rb
+++ b/core/app/models/spree/promotion.rb
@@ -1,6 +1,7 @@
 module Spree
   class Promotion < Spree::Base
     include MultiStoreResource
+    include Metadata
 
     MATCH_POLICIES = %w(all any)
     UNACTIVATABLE_ORDER_STATES = ['complete', 'awaiting_return', 'returned']

--- a/core/app/models/spree/property.rb
+++ b/core/app/models/spree/property.rb
@@ -1,6 +1,7 @@
 module Spree
   class Property < Spree::Base
     include Spree::FilterParam
+    include Metadata
 
     auto_strip_attributes :name, :presentation
 

--- a/core/app/models/spree/prototype.rb
+++ b/core/app/models/spree/prototype.rb
@@ -1,5 +1,7 @@
 module Spree
   class Prototype < Spree::Base
+    include Metadata
+
     has_many :property_prototypes, class_name: 'Spree::PropertyPrototype'
     has_many :properties, through: :property_prototypes, class_name: 'Spree::Property'
 

--- a/core/app/models/spree/refund.rb
+++ b/core/app/models/spree/refund.rb
@@ -1,5 +1,7 @@
 module Spree
   class Refund < Spree::Base
+    include Metadata
+
     with_options inverse_of: :refunds do
       belongs_to :payment
       belongs_to :reimbursement, optional: true

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -5,6 +5,7 @@ module Spree
     include Spree::Core::NumberGenerator.new(prefix: 'H', length: 11)
     include NumberIdentifier
     include NumberAsParam
+    include Metadata
 
     with_options inverse_of: :shipments do
       belongs_to :address, class_name: 'Spree::Address'

--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -2,6 +2,8 @@ module Spree
   class ShippingMethod < Spree::Base
     acts_as_paranoid
     include Spree::CalculatedAdjustments
+    include Metadata
+
     DISPLAY = [:both, :front_end, :back_end]
 
     # Used for #refresh_rates

--- a/core/app/models/spree/stock_transfer.rb
+++ b/core/app/models/spree/stock_transfer.rb
@@ -3,6 +3,7 @@ module Spree
     include Spree::Core::NumberGenerator.new(prefix: 'T')
     include NumberIdentifier
     include NumberAsParam
+    include Metadata
 
     has_many :stock_movements, as: :originator
 

--- a/core/app/models/spree/store_credit.rb
+++ b/core/app/models/spree/store_credit.rb
@@ -1,6 +1,7 @@
 module Spree
   class StoreCredit < Spree::Base
     include SingleStoreResource
+    include Metadata
 
     acts_as_paranoid
 

--- a/core/app/models/spree/taxon.rb
+++ b/core/app/models/spree/taxon.rb
@@ -3,6 +3,8 @@ require 'stringex'
 
 module Spree
   class Taxon < Spree::Base
+    include Metadata
+
     extend FriendlyId
     friendly_id :permalink, slug_column: :permalink, use: :history
     before_validation :set_permalink, on: :create, if: :name

--- a/core/app/models/spree/taxonomy.rb
+++ b/core/app/models/spree/taxonomy.rb
@@ -1,5 +1,7 @@
 module Spree
   class Taxonomy < Spree::Base
+    include Metadata
+
     acts_as_list
 
     validates :name, presence: true, uniqueness: { case_sensitive: false, allow_blank: true, scope: :store_id }

--- a/core/app/models/spree/variant.rb
+++ b/core/app/models/spree/variant.rb
@@ -4,6 +4,7 @@ module Spree
     acts_as_list scope: :product
 
     include MemoizedData
+    include Metadata
 
     MEMOIZED_METHODS = %w(purchasable in_stock backorderable tax_category options_text compare_at_price)
 

--- a/core/db/migrate/20210915064321_add_metadata_to_spree_orders.rb
+++ b/core/db/migrate/20210915064321_add_metadata_to_spree_orders.rb
@@ -1,0 +1,13 @@
+class AddMetadataToSpreeOrders < ActiveRecord::Migration[5.2]
+  def change
+    change_table :spree_orders do |t|
+      if t.respond_to? :jsonb
+        add_column :spree_orders, :public_metadata, :jsonb
+        add_column :spree_orders, :private_metadata, :jsonb
+      else
+        add_column :spree_orders, :public_metadata, :json
+        add_column :spree_orders, :private_metadata, :json
+      end
+    end
+  end
+end

--- a/core/db/migrate/20210915064322_add_metadata_to_spree_products.rb
+++ b/core/db/migrate/20210915064322_add_metadata_to_spree_products.rb
@@ -1,0 +1,13 @@
+class AddMetadataToSpreeProducts < ActiveRecord::Migration[5.2]
+  def change
+    change_table :spree_products do |t|
+      if t.respond_to? :jsonb
+        add_column :spree_products, :public_metadata, :jsonb
+        add_column :spree_products, :private_metadata, :jsonb
+      else
+        add_column :spree_products, :public_metadata, :json
+        add_column :spree_products, :private_metadata, :json
+      end
+    end
+  end
+end

--- a/core/db/migrate/20210915064323_add_metadata_to_spree_variants.rb
+++ b/core/db/migrate/20210915064323_add_metadata_to_spree_variants.rb
@@ -1,0 +1,13 @@
+class AddMetadataToSpreeVariants < ActiveRecord::Migration[5.2]
+  def change
+    change_table :spree_variants do |t|
+      if t.respond_to? :jsonb
+        add_column :spree_variants, :public_metadata, :jsonb
+        add_column :spree_variants, :private_metadata, :jsonb
+      else
+        add_column :spree_variants, :public_metadata, :json
+        add_column :spree_variants, :private_metadata, :json
+      end
+    end
+  end
+end

--- a/core/db/migrate/20210915064324_add_metadata_to_spree_line_items.rb
+++ b/core/db/migrate/20210915064324_add_metadata_to_spree_line_items.rb
@@ -1,0 +1,13 @@
+class AddMetadataToSpreeLineItems < ActiveRecord::Migration[5.2]
+  def change
+    change_table :spree_line_items do |t|
+      if t.respond_to? :jsonb
+        add_column :spree_line_items, :public_metadata, :jsonb
+        add_column :spree_line_items, :private_metadata, :jsonb
+      else
+        add_column :spree_line_items, :public_metadata, :json
+        add_column :spree_line_items, :private_metadata, :json
+      end
+    end
+  end
+end

--- a/core/db/migrate/20210915064325_add_metadata_to_spree_shipments.rb
+++ b/core/db/migrate/20210915064325_add_metadata_to_spree_shipments.rb
@@ -1,0 +1,13 @@
+class AddMetadataToSpreeShipments < ActiveRecord::Migration[5.2]
+  def change
+    change_table :spree_shipments do |t|
+      if t.respond_to? :jsonb
+        add_column :spree_shipments, :public_metadata, :jsonb
+        add_column :spree_shipments, :private_metadata, :jsonb
+      else
+        add_column :spree_shipments, :public_metadata, :json
+        add_column :spree_shipments, :private_metadata, :json
+      end
+    end
+  end
+end

--- a/core/db/migrate/20210915064326_add_metadata_to_spree_payments.rb
+++ b/core/db/migrate/20210915064326_add_metadata_to_spree_payments.rb
@@ -1,0 +1,13 @@
+class AddMetadataToSpreePayments < ActiveRecord::Migration[5.2]
+  def change
+    change_table :spree_payments do |t|
+      if t.respond_to? :jsonb
+        add_column :spree_payments, :public_metadata, :jsonb
+        add_column :spree_payments, :private_metadata, :jsonb
+      else
+        add_column :spree_payments, :public_metadata, :json
+        add_column :spree_payments, :private_metadata, :json
+      end
+    end
+  end
+end

--- a/core/db/migrate/20210915064327_add_metadata_to_spree_taxons_and_taxonomies.rb
+++ b/core/db/migrate/20210915064327_add_metadata_to_spree_taxons_and_taxonomies.rb
@@ -1,0 +1,18 @@
+class AddMetadataToSpreeTaxonsAndTaxonomies < ActiveRecord::Migration[5.2]
+  def change
+    %i[
+      spree_taxons
+      spree_taxonomies
+    ].each do |table_name|
+      change_table table_name do |t|
+        if t.respond_to? :jsonb
+          add_column table_name, :public_metadata, :jsonb
+          add_column table_name, :private_metadata, :jsonb
+        else
+          add_column table_name, :public_metadata, :json
+          add_column table_name, :private_metadata, :json
+        end
+      end
+    end
+  end
+end

--- a/core/db/migrate/20210915064328_add_metadata_to_spree_stock_transfers.rb
+++ b/core/db/migrate/20210915064328_add_metadata_to_spree_stock_transfers.rb
@@ -1,0 +1,13 @@
+class AddMetadataToSpreeStockTransfers < ActiveRecord::Migration[5.2]
+  def change
+    change_table :spree_stock_transfers do |t|
+      if t.respond_to? :jsonb
+        add_column :spree_stock_transfers, :public_metadata, :jsonb
+        add_column :spree_stock_transfers, :private_metadata, :jsonb
+      else
+        add_column :spree_stock_transfers, :public_metadata, :json
+        add_column :spree_stock_transfers, :private_metadata, :json
+      end
+    end
+  end
+end

--- a/core/db/migrate/20210915064329_add_metadata_to_spree_multiple_tables.rb
+++ b/core/db/migrate/20210915064329_add_metadata_to_spree_multiple_tables.rb
@@ -1,0 +1,30 @@
+class AddMetadataToSpreeMultipleTables < ActiveRecord::Migration[5.2]
+  def change
+    %i[
+      spree_assets
+      spree_option_types
+      spree_option_values
+      spree_properties
+      spree_promotions
+      spree_payment_methods
+      spree_shipping_methods
+      spree_prototypes
+      spree_refunds
+      spree_customer_returns
+      spree_users
+      spree_addresses
+      spree_credit_cards
+      spree_store_credits
+    ].each do |table_name|
+      change_table table_name do |t|
+        if t.respond_to? :jsonb
+          add_column table_name, :public_metadata, :jsonb
+          add_column table_name, :private_metadata, :jsonb
+        else
+          add_column table_name, :public_metadata, :json
+          add_column table_name, :private_metadata, :json
+        end
+      end
+    end
+  end
+end

--- a/core/lib/spree/testing_support/factories/stock_item_factory.rb
+++ b/core/lib/spree/testing_support/factories/stock_item_factory.rb
@@ -4,6 +4,13 @@ FactoryBot.define do
     stock_location
     variant
 
+    before(:create) do |stock_item|
+      Spree::StockItem.find_by(
+        variant: stock_item.variant,
+        stock_location: stock_item.stock_location
+      )&.destroy
+    end
+
     after(:create) { |object| object.adjust_count_on_hand(10) }
   end
 end

--- a/core/spec/models/spree/address_spec.rb
+++ b/core/spec/models/spree/address_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe Spree::Address, type: :model do
+  it_behaves_like 'metadata'
+
   describe 'clone' do
     it 'creates a copy of the address with the exception of the id, label, user_id, updated_at and created_at attributes' do
       state = create(:state)

--- a/core/spec/models/spree/asset_spec.rb
+++ b/core/spec/models/spree/asset_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe Spree::Asset, type: :model do
+  it_behaves_like 'metadata'
+end

--- a/core/spec/models/spree/base_spec.rb
+++ b/core/spec/models/spree/base_spec.rb
@@ -57,11 +57,11 @@ describe Spree::Base do
       expect(Spree::LegacyUser.json_api_columns).to include('email')
     end
 
-    it { expect(Spree::Address.json_api_columns).to contain_exactly('address1', 'address2', 'alternative_phone', 'city', 'company', 'created_at', 'deleted_at', 'firstname', 'label', 'lastname', 'phone', 'state_name', 'updated_at', 'zipcode') }
+    it { expect(Spree::Address.json_api_columns).to contain_exactly('address1', 'address2', 'alternative_phone', 'city', 'company', 'created_at', 'deleted_at', 'firstname', 'label', 'lastname', 'phone', 'state_name', 'updated_at', 'zipcode', 'public_metadata', 'private_metadata') }
     it { expect(Spree::Address.json_api_columns).not_to include('country_id') }
   end
 
   describe '.json_api_permitted_attributes' do
-    it { expect(Spree::Address.json_api_permitted_attributes).to contain_exactly('firstname', 'lastname', 'address1', 'address2', 'city', 'zipcode', 'phone', 'state_name', 'alternative_phone', 'company', 'state_id', 'country_id', 'created_at', 'updated_at', 'user_id', 'deleted_at', 'label') }
+    it { expect(Spree::Address.json_api_permitted_attributes).to contain_exactly('firstname', 'lastname', 'address1', 'address2', 'city', 'zipcode', 'phone', 'state_name', 'alternative_phone', 'company', 'state_id', 'country_id', 'created_at', 'updated_at', 'user_id', 'deleted_at', 'label', 'public_metadata', 'private_metadata') }
   end
 end

--- a/core/spec/models/spree/credit_card_spec.rb
+++ b/core/spec/models/spree/credit_card_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe Spree::CreditCard, type: :model do
+  it_behaves_like 'metadata'
+
   let(:credit_card) { Spree::CreditCard.new }
   let(:valid_credit_card_attributes) do
     {

--- a/core/spec/models/spree/customer_return_spec.rb
+++ b/core/spec/models/spree/customer_return_spec.rb
@@ -5,6 +5,8 @@ describe Spree::CustomerReturn, type: :model do
     allow_any_instance_of(Spree::Order).to receive_messages(return!: true)
   end
 
+  it_behaves_like 'metadata'
+
   describe '.validation' do
     describe '#must_have_return_authorization' do
       subject { customer_return.valid? }

--- a/core/spec/models/spree/line_item_spec.rb
+++ b/core/spec/models/spree/line_item_spec.rb
@@ -5,6 +5,8 @@ describe Spree::LineItem, type: :model do
   let(:order) { create :order_with_line_items, line_items_count: 1, store: store }
   let(:line_item) { order.line_items.first }
 
+  it_behaves_like 'metadata'
+
   describe 'Validations' do
     describe 'ensure_proper_currency' do
       context 'order is present' do

--- a/core/spec/models/spree/option_type_spec.rb
+++ b/core/spec/models/spree/option_type_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe Spree::OptionType, type: :model do
+  it_behaves_like 'metadata'
+
   context 'touching' do
     it 'touches a product' do
       product_option_type = create(:product_option_type)

--- a/core/spec/models/spree/option_value_spec.rb
+++ b/core/spec/models/spree/option_value_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe Spree::OptionValue, type: :model do
+  it_behaves_like 'metadata'
+
   context 'touching' do
     it 'touches a variant' do
       variant = create(:variant)

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -13,6 +13,8 @@ describe Spree::Order, type: :model do
 
   before { allow(Spree::LegacyUser).to receive_messages(current: create(:user)) }
 
+  it_behaves_like 'metadata'
+
   describe '.scopes' do
     let!(:user) { FactoryBot.create(:user) }
     let!(:completed_order) { FactoryBot.create(:order, user: user, completed_at: Time.current) }

--- a/core/spec/models/spree/payment_method_spec.rb
+++ b/core/spec/models/spree/payment_method_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe Spree::PaymentMethod, type: :model do
+  it_behaves_like 'metadata'
+
   let(:store) { create(:store) }
 
   context 'visibility scopes' do

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -47,6 +47,8 @@ describe Spree::Payment, type: :model do
     allow(payment).to receive(:payment_method_available_for_order).and_return(nil)
   end
 
+  it_behaves_like 'metadata'
+
   describe 'Constants' do
     it { expect(Spree::Payment::INVALID_STATES).to eq(%w(failed invalid)) }
   end

--- a/core/spec/models/spree/product_spec.rb
+++ b/core/spec/models/spree/product_spec.rb
@@ -8,6 +8,8 @@ module ThirdParty
 end
 
 describe Spree::Product, type: :model do
+  it_behaves_like 'metadata'
+
   let!(:store) { create(:store) }
 
   context 'product instance' do

--- a/core/spec/models/spree/promotion_spec.rb
+++ b/core/spec/models/spree/promotion_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe Spree::Promotion, type: :model do
+  it_behaves_like 'metadata'
+
   let(:store) { create(:store) }
   let(:promotion) { create(:promotion) }
 

--- a/core/spec/models/spree/property_spec.rb
+++ b/core/spec/models/spree/property_spec.rb
@@ -3,6 +3,8 @@ require 'spec_helper'
 describe Spree::Property, type: :model do
   let(:store) { create(:store) }
 
+  it_behaves_like 'metadata'
+
   context 'setting filter param' do
     subject { build(:property, name: 'Brand Name') }
 

--- a/core/spec/models/spree/prototype_spec.rb
+++ b/core/spec/models/spree/prototype_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe Spree::Prototype, type: :model do
+  it_behaves_like 'metadata'
+end

--- a/core/spec/models/spree/refund_spec.rb
+++ b/core/spec/models/spree/refund_spec.rb
@@ -1,6 +1,14 @@
 require 'spec_helper'
 
 describe Spree::Refund, type: :model do
+  describe 'metadata' do
+    before do
+      allow_any_instance_of(Spree::Refund).to receive(:amount_is_less_than_or_equal_to_allowed_amount)
+    end
+
+    it_behaves_like 'metadata'
+  end
+
   describe 'create' do
     subject { create(:refund, payment: payment, amount: amount, reason: refund_reason, transaction_id: nil) }
 

--- a/core/spec/models/spree/shipment_spec.rb
+++ b/core/spec/models/spree/shipment_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe Spree::Shipment, type: :model do
+  it_behaves_like 'metadata'
+
   let!(:order) { create(:order, number: 'S12345') }
   let(:shipping_method) { create(:shipping_method, name: 'UPS') }
   let(:shipment) do

--- a/core/spec/models/spree/shipping_method_spec.rb
+++ b/core/spec/models/spree/shipping_method_spec.rb
@@ -9,6 +9,8 @@ describe Spree::ShippingMethod, type: :model do
   let(:backend_shipping_method) { create :shipping_method, display_on: 'back_end' }
   let(:front_and_back_end_shipping_method) { create :shipping_method, display_on: 'both' }
 
+  it_behaves_like 'metadata'
+
   context 'calculators' do
     it "rejects calculators that don't inherit from Spree::ShippingCalculator" do
       allow(Spree::ShippingMethod).to receive_message_chain(:spree_calculators, :shipping_methods).and_return([

--- a/core/spec/models/spree/stock_transfer_spec.rb
+++ b/core/spec/models/spree/stock_transfer_spec.rb
@@ -9,6 +9,8 @@ module Spree
     let(:stock_item) { source_location.stock_items.order(:id).first }
     let(:variant) { stock_item.variant }
 
+    it_behaves_like 'metadata'
+
     describe '#reference' do
       subject { super().reference }
 

--- a/core/spec/models/spree/store_credit_spec.rb
+++ b/core/spec/models/spree/store_credit_spec.rb
@@ -1,9 +1,11 @@
 require 'spec_helper'
 
-describe 'StoreCredit' do
+describe Spree::StoreCredit, type: :model do
   let(:currency) { 'TEST' }
   let(:store_credit) { build(:store_credit, store_credit_attrs) }
   let(:store_credit_attrs) { {} }
+
+  it_behaves_like 'metadata'
 
   describe 'callbacks' do
     subject { store_credit.save }

--- a/core/spec/models/spree/taxon_spec.rb
+++ b/core/spec/models/spree/taxon_spec.rb
@@ -4,6 +4,8 @@ describe Spree::Taxon, type: :model do
   let(:taxonomy) { create(:taxonomy) }
   let(:taxon) { build(:taxon, name: 'Ruby on Rails', parent: nil) }
 
+  it_behaves_like 'metadata'
+
   describe '#to_param' do
     subject { super().to_param }
 

--- a/core/spec/models/spree/taxonomy_spec.rb
+++ b/core/spec/models/spree/taxonomy_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe Spree::Taxonomy, type: :model do
+  it_behaves_like 'metadata'
+
   context '#destroy' do
     before do
       @taxonomy = create(:taxonomy)

--- a/core/spec/models/spree/user_spec.rb
+++ b/core/spec/models/spree/user_spec.rb
@@ -11,6 +11,8 @@ describe Spree::LegacyUser, type: :model do # rubocop:disable RSpec/MultipleDesc
     let(:order_2) { create(:order, user: user, created_by: user, store: store) }
     let(:order_3) { create(:order, user: user, created_by: create(:user), store: store) }
 
+    it_behaves_like 'metadata', factory: :user
+
     it 'returns correct order' do
       Timecop.scale(3600) do
         order_1

--- a/core/spec/models/spree/variant_spec.rb
+++ b/core/spec/models/spree/variant_spec.rb
@@ -6,6 +6,7 @@ describe Spree::Variant, type: :model do
   let(:master_variant) { create(:master_variant) }
 
   it_behaves_like 'default_price'
+  it_behaves_like 'metadata'
 
   context 'sorting' do
     it 'responds to set_list_position' do

--- a/core/spec/support/concerns/metadata.rb
+++ b/core/spec/support/concerns/metadata.rb
@@ -1,0 +1,23 @@
+shared_examples_for 'metadata' do |factory: described_class.name.demodulize.underscore.to_sym|
+  subject { FactoryBot.create(factory) }
+
+  it { expect(subject.has_attribute?(:public_metadata)).to be_truthy }
+  it { expect(subject.has_attribute?(:private_metadata)).to be_truthy }
+
+  it { expect(subject.public_metadata.class).to eq(HashWithIndifferentAccess) }
+  it { expect(subject.private_metadata.class).to eq(HashWithIndifferentAccess) }
+
+  it do
+    string = subject.public_metadata[:color] = 'red'
+    number = subject.public_metadata[:priority] = 1
+    array = subject.public_metadata[:keywords] = ['k1', 'k2']
+    hash = subject.public_metadata[:additional_data] = { size: 'big', material: 'wool' }
+
+    subject.save!
+
+    expect(subject.public_metadata[:color]).to eq(string)
+    expect(subject.public_metadata[:priority]).to eq(number)
+    expect(subject.public_metadata[:keywords]).to eq(array)
+    expect(subject.public_metadata[:additional_data]).to eq(hash.stringify_keys)
+  end
+end


### PR DESCRIPTION
* SD-1352 - As a System I can store MetaData for Spree Resources - Metadata concern

* SD-1352 - As a System I can store MetaData for Spree Resources - Orders

* SD-1352 - As a System I can store MetaData for Spree Resources - Products

* SD-1352 - As a System I can store MetaData for Spree Resources - Variants

* SD-1352 - As a System I can store MetaData for Spree Resources - Users

* SD-1352 - As a System I can store MetaData for Spree Resources - Line Items

* SD-1352 - As a System I can store MetaData for Spree Resources - Shipments

* SD-1352 - As a System I can store MetaData for Spree Resources - Payments

* SD-1352 - As a System I can store MetaData for Spree Resources - Taxons and Taxonomies

* SD-1352 - As a System I can store MetaData for Spree Resources - Stock Movements and Stock Transfers

* SD-1352 - As a System I can store MetaData for Spree Resources - multiple models

Co-authored-by: Damian Legawiec <damian@sparksolutions.co>